### PR TITLE
(Test) unit tests for review feature

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/ro/unibuc/triplea/domain/games/steam/exception/SteamGameValidateException.java
+++ b/src/main/java/ro/unibuc/triplea/domain/games/steam/exception/SteamGameValidateException.java
@@ -1,7 +1,0 @@
-package ro.unibuc.triplea.domain.games.steam.exception;
-
-public class SteamGameValidateException extends RuntimeException {
-    public SteamGameValidateException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/ro/unibuc/triplea/domain/games/steam/exception/advice/SteamGameExceptionHandler.java
+++ b/src/main/java/ro/unibuc/triplea/domain/games/steam/exception/advice/SteamGameExceptionHandler.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameStandardResponse;
 import ro.unibuc.triplea.domain.games.steam.exception.SteamGameNotFoundException;
-import ro.unibuc.triplea.domain.games.steam.exception.SteamGameValidateException;
 
 @RestControllerAdvice
 @CrossOrigin
@@ -19,12 +18,7 @@ public class SteamGameExceptionHandler {
     public ResponseEntity<SteamGameStandardResponse> handleNotFoundException(SteamGameNotFoundException e) {
         return new ResponseEntity<SteamGameStandardResponse>(new SteamGameStandardResponse("404", "Error", e.getMessage()), HttpStatus.NOT_FOUND);
     }
-
-    @ExceptionHandler(SteamGameValidateException.class)
-    public ResponseEntity<SteamGameStandardResponse> handleValidationException(SteamGameValidateException e) {
-        return new ResponseEntity<SteamGameStandardResponse>(new SteamGameStandardResponse("400", "Error", e.getMessage()), HttpStatus.BAD_REQUEST);
-    }
-
+    
     @ExceptionHandler(Exception.class)
     public ResponseEntity<SteamGameStandardResponse> handleException(Exception e) throws Exception {
         return new ResponseEntity<SteamGameStandardResponse>(new SteamGameStandardResponse("500", "Error", e.getMessage()), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/ro/unibuc/triplea/domain/games/steam/service/SteamGameService.java
+++ b/src/main/java/ro/unibuc/triplea/domain/games/steam/service/SteamGameService.java
@@ -29,23 +29,16 @@ public class SteamGameService {
     }
 
     public Optional<SteamGameResponse> getGameByIdentifier(String identifier) {
+        Optional<SteamGameResponse> game;
         if (IdentifierUtil.isNumeric(identifier)) {
             int steamId = Integer.parseInt(identifier);
-            Optional<SteamGameResponse> game = getGameBySteamId(steamId);
-
-            if (game.isPresent()) {
-                return game;
-            } else {
-                throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
-            }
+            game = getGameBySteamId(steamId);
         } else {
-            Optional<SteamGameResponse> game = getGameByName(identifier);
-
-            if (game.isPresent()) {
-                return game;
-            } else {
-                throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
-            }
+            game = getGameByName(identifier);
         }
+        if (game.isEmpty()) {
+            throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
+        }
+        return game;
     }
 }

--- a/src/main/java/ro/unibuc/triplea/domain/games/steam/service/SteamGameService.java
+++ b/src/main/java/ro/unibuc/triplea/domain/games/steam/service/SteamGameService.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameResponse;
 import ro.unibuc.triplea.domain.games.steam.exception.SteamGameNotFoundException;
-import ro.unibuc.triplea.domain.games.steam.exception.SteamGameValidateException;
 import ro.unibuc.triplea.domain.games.steam.repository.SteamGameRepository;
 import ro.unibuc.triplea.domain.games.steam.utils.IdentifierUtil;
 
@@ -39,7 +38,7 @@ public class SteamGameService {
             } else {
                 throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
             }
-        } else if (IdentifierUtil.isValidString(identifier)) {
+        } else {
             Optional<SteamGameResponse> game = getGameByName(identifier);
 
             if (game.isPresent()) {
@@ -47,8 +46,6 @@ public class SteamGameService {
             } else {
                 throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
             }
-        } else {
-            throw new SteamGameValidateException("Invalid identifier: " + identifier);
         }
     }
 }

--- a/src/main/java/ro/unibuc/triplea/domain/games/steam/utils/IdentifierUtil.java
+++ b/src/main/java/ro/unibuc/triplea/domain/games/steam/utils/IdentifierUtil.java
@@ -1,7 +1,5 @@
 package ro.unibuc.triplea.domain.games.steam.utils;
 
-import java.util.regex.Pattern;
-
 public final class IdentifierUtil {
 
     private IdentifierUtil() {
@@ -10,9 +8,5 @@ public final class IdentifierUtil {
 
     public static boolean isNumeric(String str) {
         return str.matches("\\d+");
-    }
-
-    public static boolean isValidString(String str) {
-        return Pattern.matches("^([^\\\\u4E00-\\\\u9FFF]*?)(?:[\\\\p{L}0-9' .:~\\\\u4E00-\\\\u9FFF].*)?$", str);
     }
 }

--- a/src/main/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewService.java
+++ b/src/main/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewService.java
@@ -60,9 +60,11 @@ public class SteamGameReviewService {
     }
 
     private SteamGameReview convertToSteamGameReview(SteamGameReviewRequest steamGameReviewRequest, String username) {
-        Optional<SteamGameResponse> steamGameResponse = steamGameService.getGameBySteamId(steamGameReviewRequest.getGameSteamId());
+        Optional<SteamGameResponse> steamGameResponse = steamGameService
+                .getGameBySteamId(steamGameReviewRequest.getGameSteamId());
         if (steamGameResponse.isEmpty()) {
-            throw new SteamGameNotFoundException("Steam game with identifier " + steamGameReviewRequest.getGameSteamId() + " not found");
+            throw new SteamGameNotFoundException(
+                    "Steam game with identifier " + steamGameReviewRequest.getGameSteamId() + " not found");
         }
 
         return SteamGameReview.builder()

--- a/src/main/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewService.java
+++ b/src/main/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewService.java
@@ -30,24 +30,17 @@ public class SteamGameReviewService {
     }
 
     public Optional<List<SteamGameReviewResponse>> getReviewsByGameIdentifier(String identifier) {
+        Optional<List<SteamGameReviewResponse>> steamGameReviewResponses;
         if (IdentifierUtil.isNumeric(identifier)) {
             int steamId = Integer.parseInt(identifier);
-            Optional<List<SteamGameReviewResponse>> steamGameReviewResponses = getReviewsBySteamId(steamId);
-
-            if (steamGameReviewResponses.isPresent()) {
-                return steamGameReviewResponses;
-            } else {
-                throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
-            }
+            steamGameReviewResponses = getReviewsBySteamId(steamId);
         } else {
-            Optional<List<SteamGameReviewResponse>> steamGameReviewResponses = getReviewsByGameName(identifier);
-
-            if (steamGameReviewResponses.isPresent()) {
-                return steamGameReviewResponses;
-            } else {
-                throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
-            }
+            steamGameReviewResponses = getReviewsByGameName(identifier);
         }
+        if (steamGameReviewResponses.isEmpty()) {
+            throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
+        }
+        return steamGameReviewResponses;
     }
 
     public Optional<SteamGameReviewResponse> addReview(SteamGameReviewRequest game, UserDetails userDetails) {

--- a/src/main/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewService.java
+++ b/src/main/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewService.java
@@ -39,7 +39,7 @@ public class SteamGameReviewService {
             } else {
                 throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
             }
-        } else if (IdentifierUtil.isValidString(identifier)) {
+        } else {
             Optional<List<SteamGameReviewResponse>> steamGameReviewResponses = getReviewsByGameName(identifier);
 
             if (steamGameReviewResponses.isPresent()) {
@@ -47,8 +47,6 @@ public class SteamGameReviewService {
             } else {
                 throw new SteamGameNotFoundException("Steam game with identifier " + identifier + " not found");
             }
-        } else {
-            throw new SteamGameNotFoundException("Invalid identifier: " + identifier);
         }
     }
 

--- a/src/test/java/ro/unibuc/triplea/application/games/steam/web/SteamGameControllerTest.java
+++ b/src/test/java/ro/unibuc/triplea/application/games/steam/web/SteamGameControllerTest.java
@@ -1,7 +1,6 @@
 package ro.unibuc.triplea.application.games.steam.web;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.http.ResponseEntity;
 import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameResponse;
 import ro.unibuc.triplea.domain.games.steam.service.SteamGameService;
@@ -12,11 +11,13 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 public class SteamGameControllerTest {
 
-    private final SteamGameService steamGameService = Mockito.mock(SteamGameService.class);
-    private final SteamGameController steamGameController = new SteamGameController(steamGameService);
+    private SteamGameService steamGameService = mock(SteamGameService.class);
+
+    private SteamGameController steamGameController = new SteamGameController(steamGameService);
 
     @Test
     public void testGetAllGames() {

--- a/src/test/java/ro/unibuc/triplea/application/reviews/steam/web/SteamGameReviewControllerTest.java
+++ b/src/test/java/ro/unibuc/triplea/application/reviews/steam/web/SteamGameReviewControllerTest.java
@@ -1,7 +1,7 @@
 package ro.unibuc.triplea.application.reviews.steam.web;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -15,13 +15,15 @@ import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 public class SteamGameReviewControllerTest {
+        
+    private final SteamGameReviewService steamGameReviewService = mock(SteamGameReviewService.class);
 
-    private final SteamGameReviewService steamGameReviewService = Mockito.mock(SteamGameReviewService.class);
+    private final UserDetails userDetails = mock(UserDetails.class);
 
-    private final SteamGameReviewController steamGameReviewController = new SteamGameReviewController(
-            steamGameReviewService);
+    private final SteamGameReviewController steamGameReviewController = new SteamGameReviewController(steamGameReviewService);
 
     @Test
     public void testGetReviewsBySteamId() {
@@ -95,8 +97,6 @@ public class SteamGameReviewControllerTest {
                 .reviewContent("Great game!")
                 .build();
 
-        UserDetails userDetails = Mockito.mock(UserDetails.class);
-
         SteamGameReviewResponse reviewResponse = SteamGameReviewResponse.builder()
                 .gameSteamId(0)
                 .gameName("Game")
@@ -117,8 +117,6 @@ public class SteamGameReviewControllerTest {
                 .gameSteamId(0)
                 .reviewContent(null) // Set review content as null to simulate a bad request
                 .build();
-
-        UserDetails userDetails = Mockito.mock(UserDetails.class);
 
         ResponseEntity<?> responseEntity = steamGameReviewController.addReview(reviewRequest, userDetails);
 

--- a/src/test/java/ro/unibuc/triplea/application/reviews/steam/web/SteamGameReviewControllerTest.java
+++ b/src/test/java/ro/unibuc/triplea/application/reviews/steam/web/SteamGameReviewControllerTest.java
@@ -1,21 +1,10 @@
 package ro.unibuc.triplea.application.reviews.steam.web;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameResponse;
 import ro.unibuc.triplea.application.reviews.steam.dto.request.SteamGameReviewRequest;
 import ro.unibuc.triplea.application.reviews.steam.dto.response.SteamGameReviewResponse;
 import ro.unibuc.triplea.domain.reviews.steam.service.SteamGameReviewService;

--- a/src/test/java/ro/unibuc/triplea/application/reviews/steam/web/SteamGameReviewControllerTest.java
+++ b/src/test/java/ro/unibuc/triplea/application/reviews/steam/web/SteamGameReviewControllerTest.java
@@ -1,0 +1,138 @@
+package ro.unibuc.triplea.application.reviews.steam.web;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameResponse;
+import ro.unibuc.triplea.application.reviews.steam.dto.request.SteamGameReviewRequest;
+import ro.unibuc.triplea.application.reviews.steam.dto.response.SteamGameReviewResponse;
+import ro.unibuc.triplea.domain.reviews.steam.service.SteamGameReviewService;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class SteamGameReviewControllerTest {
+
+    private final SteamGameReviewService steamGameReviewService = Mockito.mock(SteamGameReviewService.class);
+
+    private final SteamGameReviewController steamGameReviewController = new SteamGameReviewController(
+            steamGameReviewService);
+
+    @Test
+    public void testGetReviewsBySteamId() {
+        String gameId = "123";
+
+        List<SteamGameReviewResponse> reviews = Arrays.asList(
+                SteamGameReviewResponse.builder()
+                        .userName("user1")
+                        .reviewContent("Great game!")
+                        .build(),
+                SteamGameReviewResponse.builder()
+                        .userName("user2")
+                        .reviewContent("Awesome graphics!")
+                        .build());
+
+        when(steamGameReviewService.getReviewsByGameIdentifier(gameId)).thenReturn(Optional.of(reviews));
+
+        ResponseEntity<?> responseEntity = steamGameReviewController.getReviewsBySteamId(gameId);
+
+        assertEquals(ResponseEntity.ok(reviews), responseEntity);
+
+    }
+
+    @Test
+    public void testGetReviewsBySteamId_SteamIdNotFound() {
+        String gameId = "456";
+
+        when(steamGameReviewService.getReviewsByGameIdentifier(gameId)).thenReturn(Optional.empty());
+
+        ResponseEntity<?> responseEntity = steamGameReviewController.getReviewsBySteamId(gameId);
+
+        assertEquals(ResponseEntity.notFound().build(), responseEntity);
+    }
+
+    @Test
+    public void testGetReviewsByUserId() {
+        String userName = "user1";
+
+        List<SteamGameReviewResponse> reviews = Arrays.asList(
+                SteamGameReviewResponse.builder()
+                        .userName("user1")
+                        .reviewContent("Great game!")
+                        .build(),
+                SteamGameReviewResponse.builder()
+                        .userName("user1")
+                        .reviewContent("Awesome graphics!")
+                        .build());
+
+        when(steamGameReviewService.getReviewsByUserName(userName)).thenReturn(Optional.of(reviews));
+
+        ResponseEntity<?> responseEntity = steamGameReviewController.getReviewsByUserId(userName);
+
+        assertEquals(ResponseEntity.ok(reviews), responseEntity);
+    }
+
+    @Test
+    public void testGetReviewsByUserId_UserNotFound() {
+        String userName = "user3";
+
+        when(steamGameReviewService.getReviewsByUserName(userName)).thenReturn(Optional.empty());
+
+        ResponseEntity<?> responseEntity = steamGameReviewController.getReviewsByUserId(userName);
+
+        assertEquals(ResponseEntity.notFound().build(), responseEntity);
+    }
+
+    @Test
+    public void testAddReview() {
+        SteamGameReviewRequest reviewRequest = SteamGameReviewRequest.builder()
+                .gameSteamId(0)
+                .reviewContent("Great game!")
+                .build();
+
+        UserDetails userDetails = Mockito.mock(UserDetails.class);
+
+        SteamGameReviewResponse reviewResponse = SteamGameReviewResponse.builder()
+                .gameSteamId(0)
+                .gameName("Game")
+                .userName("user1")
+                .reviewContent("Great game!")
+                .build();
+
+        when(steamGameReviewService.addReview(reviewRequest, userDetails)).thenReturn(Optional.of(reviewResponse));
+
+        ResponseEntity<?> responseEntity = steamGameReviewController.addReview(reviewRequest, userDetails);
+
+        assertEquals(ResponseEntity.ok(reviewResponse), responseEntity);
+    }
+
+    @Test
+    public void testAddReview_BadRequest() {
+        SteamGameReviewRequest reviewRequest = SteamGameReviewRequest.builder()
+                .gameSteamId(0)
+                .reviewContent(null) // Set review content as null to simulate a bad request
+                .build();
+
+        UserDetails userDetails = Mockito.mock(UserDetails.class);
+
+        ResponseEntity<?> responseEntity = steamGameReviewController.addReview(reviewRequest, userDetails);
+
+        assertEquals(ResponseEntity.badRequest().build(), responseEntity);
+    }
+}

--- a/src/test/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewServiceTest.java
+++ b/src/test/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewServiceTest.java
@@ -1,9 +1,6 @@
 package ro.unibuc.triplea.domain.reviews.steam.service;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameResponse;
@@ -20,24 +17,17 @@ import java.util.Optional;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.*;
 
 public class SteamGameReviewServiceTest {
 
-    private SteamGameReviewService steamGameReviewService;
+    private SteamGameReviewRepository steamGameReviewRepository = mock(SteamGameReviewRepository.class);
 
-    @Mock
-    private SteamGameReviewRepository steamGameReviewRepository;
+    private SteamGameService steamGameService = mock(SteamGameService.class);
 
-    @Mock
-    private SteamGameService steamGameService;
-
-    @BeforeEach
-    public void setUp() {
-        MockitoAnnotations.openMocks(this);
-        steamGameReviewService = new SteamGameReviewService(steamGameReviewRepository, steamGameService);
-    }
+    private SteamGameReviewService steamGameReviewService = new SteamGameReviewService(steamGameReviewRepository, steamGameService);
 
     @Test
     public void testGetReviewsBySteamId() {
@@ -148,16 +138,6 @@ public class SteamGameReviewServiceTest {
         Optional<List<SteamGameReviewResponse>> result = steamGameReviewService.getReviewsByGameIdentifier(gameName);
 
         assertEquals(expected.size(), result.orElse(new ArrayList<>()).size());
-    }
-
-    @Test
-    public void testGetReviewsByGameIdentifier_GameNotFound() {
-        String gameIdentifier = "game1";
-
-        when(steamGameReviewRepository.findAllByGameName(gameIdentifier)).thenReturn(Optional.empty());
-
-        assertThrows(SteamGameNotFoundException.class,
-                () -> steamGameReviewService.getReviewsByGameIdentifier(gameIdentifier));
     }
 
     @Test

--- a/src/test/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewServiceTest.java
+++ b/src/test/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewServiceTest.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;

--- a/src/test/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewServiceTest.java
+++ b/src/test/java/ro/unibuc/triplea/domain/reviews/steam/service/SteamGameReviewServiceTest.java
@@ -1,0 +1,244 @@
+package ro.unibuc.triplea.domain.reviews.steam.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import ro.unibuc.triplea.application.games.steam.dto.response.SteamGameResponse;
+import ro.unibuc.triplea.application.reviews.steam.dto.request.SteamGameReviewRequest;
+import ro.unibuc.triplea.application.reviews.steam.dto.response.SteamGameReviewResponse;
+import ro.unibuc.triplea.domain.games.steam.exception.SteamGameNotFoundException;
+import ro.unibuc.triplea.domain.games.steam.service.SteamGameService;
+import ro.unibuc.triplea.domain.reviews.steam.model.entity.SteamGameReview;
+import ro.unibuc.triplea.domain.reviews.steam.repository.SteamGameReviewRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.*;
+
+public class SteamGameReviewServiceTest {
+
+    private SteamGameReviewService steamGameReviewService;
+
+    @Mock
+    private SteamGameReviewRepository steamGameReviewRepository;
+
+    @Mock
+    private SteamGameService steamGameService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        steamGameReviewService = new SteamGameReviewService(steamGameReviewRepository, steamGameService);
+    }
+
+    @Test
+    public void testGetReviewsBySteamId() {
+        int gameSteamId = 123;
+        List<SteamGameReviewResponse> expected = new ArrayList<>();
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(gameSteamId)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(gameSteamId)
+                .gameName("game1")
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        when(steamGameReviewRepository.findAllByGameSteamId(gameSteamId)).thenReturn(Optional.of(expected));
+
+        Optional<List<SteamGameReviewResponse>> result = steamGameReviewService.getReviewsBySteamId(gameSteamId);
+
+        assertEquals(expected.size(), result.orElse(new ArrayList<>()).size());
+        verify(steamGameReviewRepository, times(1)).findAllByGameSteamId(gameSteamId);
+    }
+
+    @Test
+    public void testGetReviewsByGameName() {
+        String gameName = "game1";
+        List<SteamGameReviewResponse> expected = new ArrayList<>();
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(123)
+                .gameName(gameName)
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(456)
+                .gameName(gameName)
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        when(steamGameReviewRepository.findAllByGameName(gameName)).thenReturn(Optional.of(expected));
+
+        Optional<List<SteamGameReviewResponse>> result = steamGameReviewService.getReviewsByGameName(gameName);
+
+        assertEquals(expected.size(), result.orElse(new ArrayList<>()).size());
+        verify(steamGameReviewRepository, times(1)).findAllByGameName(gameName);
+    }
+
+    @Test
+    public void testGetReviewsByGameIdentifier_Id() {
+        Integer steamId = 1;
+        String gameIdentifier = steamId.toString();
+        List<SteamGameReviewResponse> expected = new ArrayList<>();
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(steamId)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(steamId)
+                .gameName("game1")
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        when(steamGameReviewRepository.findAllByGameSteamId(steamId)).thenReturn(Optional.of(expected));
+
+        Optional<List<SteamGameReviewResponse>> result = steamGameReviewService
+                .getReviewsByGameIdentifier(gameIdentifier);
+
+        assertEquals(expected.size(), result.orElse(new ArrayList<>()).size());
+    }
+
+    @Test
+    public void testGetReviewsByGameIdentifier_Id_GameNotFound() {
+        Integer steamId = 1;
+        String gameIdentifier = steamId.toString();
+
+        when(steamGameReviewRepository.findAllByGameSteamId(steamId)).thenReturn(Optional.empty());
+
+        assertThrows(SteamGameNotFoundException.class,
+                () -> steamGameReviewService.getReviewsByGameIdentifier(gameIdentifier));
+    }
+
+    @Test
+    public void testGetReviewsByGameIdentifier_GameName() {
+        String gameName = "game1";
+        List<SteamGameReviewResponse> expected = new ArrayList<>();
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName(gameName)
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expected.add(SteamGameReviewResponse.builder()
+                .gameSteamId(2)
+                .gameName(gameName)
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        when(steamGameReviewRepository.findAllByGameName(gameName)).thenReturn(Optional.of(expected));
+
+        Optional<List<SteamGameReviewResponse>> result = steamGameReviewService.getReviewsByGameIdentifier(gameName);
+
+        assertEquals(expected.size(), result.orElse(new ArrayList<>()).size());
+    }
+
+    @Test
+    public void testGetReviewsByGameIdentifier_GameNotFound() {
+        String gameIdentifier = "game1";
+
+        when(steamGameReviewRepository.findAllByGameName(gameIdentifier)).thenReturn(Optional.empty());
+
+        assertThrows(SteamGameNotFoundException.class,
+                () -> steamGameReviewService.getReviewsByGameIdentifier(gameIdentifier));
+    }
+
+    @Test
+    public void testAddReview() {
+
+        SteamGameReviewRequest gameReviewRequest = SteamGameReviewRequest.builder()
+                .gameSteamId(1)
+                .reviewContent("review1")
+                .build();
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("user1");
+        when(steamGameService.getGameBySteamId(anyInt())).thenReturn(Optional.of(SteamGameResponse.builder()
+                .gameName("game1")
+                .gameSteamId(1)
+                .build()));
+
+        SteamGameReviewResponse expectedResponse = SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build();
+        when(steamGameReviewRepository.save(any(SteamGameReview.class))).thenReturn(Optional.of(expectedResponse));
+
+        Optional<SteamGameReviewResponse> result = steamGameReviewService.addReview(gameReviewRequest, userDetails);
+
+        assertTrue(result.isPresent());
+        assertEquals(expectedResponse, result.get());
+    }
+
+    @Test
+    public void testAddReview_NonexistentGame() {
+
+        SteamGameReviewRequest gameReviewRequest = SteamGameReviewRequest.builder()
+                .gameSteamId(1)
+                .reviewContent("review1")
+                .build();
+        UserDetails userDetails = mock(UserDetails.class);
+        when(userDetails.getUsername()).thenReturn("user1");
+        when(steamGameService.getGameBySteamId(anyInt())).thenReturn(Optional.empty());
+
+        assertThrows(SteamGameNotFoundException.class,
+                () -> steamGameReviewService.addReview(gameReviewRequest, userDetails));
+    }
+
+    @Test
+    public void testGetReviewsByUserName() {
+        String username = "user1";
+        List<SteamGameReviewResponse> reviews = new ArrayList<>();
+        reviews.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        reviews.add(SteamGameReviewResponse.builder()
+                .gameSteamId(2)
+                .gameName("game2")
+                .userName("user1")
+                .reviewContent("review2")
+                .build());
+        when(steamGameReviewRepository.findAllByUserName(username)).thenReturn(Optional.of(reviews));
+
+        List<SteamGameReviewResponse> expectedResponse = new ArrayList<>();
+        expectedResponse.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expectedResponse.add(SteamGameReviewResponse.builder()
+                .gameSteamId(2)
+                .gameName("game2")
+                .userName("user1")
+                .reviewContent("review2")
+                .build());
+
+        Optional<List<SteamGameReviewResponse>> result = steamGameReviewService.getReviewsByUserName(username);
+
+        assertTrue(result.isPresent());
+        assertEquals(expectedResponse, result.get());
+    }
+}

--- a/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
+++ b/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
@@ -8,11 +8,8 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-// FILEPATH: /workspaces/service/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
+++ b/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
@@ -6,16 +6,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 import ro.unibuc.triplea.application.reviews.steam.dto.response.SteamGameReviewResponse;
 import ro.unibuc.triplea.domain.auth.model.entity.meta.User;
@@ -26,22 +23,13 @@ import ro.unibuc.triplea.infrastructure.auth.repository.SpringDataUserRepository
 
 public class SteamGameReviewRepositoryImplTest {
 
-    @Mock
-    private SpringDataSteamGameReviewRepository springDataSteamGameReviewRepository;
+    private final SpringDataSteamGameReviewRepository springDataSteamGameReviewRepository = mock(SpringDataSteamGameReviewRepository.class);
 
-    @Mock
-    private SpringDataUserRepository springDataUserRepository;
+    private final SpringDataUserRepository springDataUserRepository = mock(SpringDataUserRepository.class);
 
-    @Mock
-    private SteamGameGateway steamGameGateway;
+    private final SteamGameGateway steamGameGateway = mock(SteamGameGateway.class);
 
-    @InjectMocks
-    private SteamGameReviewRepositoryImpl steamGameReviewRepositoryImpl;
-
-    @BeforeEach
-    public void setup() {
-        MockitoAnnotations.openMocks(this);
-    }
+    private SteamGameReviewRepositoryImpl steamGameReviewRepositoryImpl = new SteamGameReviewRepositoryImpl(springDataSteamGameReviewRepository, springDataUserRepository, steamGameGateway);
 
     @Test
     public void testFindAllByGameSteamId() {

--- a/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
+++ b/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
@@ -1,0 +1,214 @@
+package ro.unibuc.triplea.infrastructure.reviews.steam.repository;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+// FILEPATH: /workspaces/service/src/test/java/ro/unibuc/triplea/infrastructure/reviews/steam/repository/SteamGameReviewRepositoryImplTest.java
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import ro.unibuc.triplea.application.reviews.steam.dto.response.SteamGameReviewResponse;
+import ro.unibuc.triplea.domain.auth.model.entity.meta.User;
+import ro.unibuc.triplea.domain.games.steam.gateway.SteamGameGateway;
+import ro.unibuc.triplea.domain.games.steam.model.entity.SteamGame;
+import ro.unibuc.triplea.domain.reviews.steam.model.entity.SteamGameReview;
+import ro.unibuc.triplea.infrastructure.auth.repository.SpringDataUserRepository;
+
+public class SteamGameReviewRepositoryImplTest {
+
+    @Mock
+    private SpringDataSteamGameReviewRepository springDataSteamGameReviewRepository;
+
+    @Mock
+    private SpringDataUserRepository springDataUserRepository;
+
+    @Mock
+    private SteamGameGateway steamGameGateway;
+
+    @InjectMocks
+    private SteamGameReviewRepositoryImpl steamGameReviewRepositoryImpl;
+
+    @BeforeEach
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    public void testFindAllByGameSteamId() {
+        when(steamGameGateway.getSteamGameBySteamId(anyInt()))
+                .thenReturn(Optional.of(SteamGame.builder().gameSteamId(1).gameName("game1").build()));
+        List<SteamGameReview> reviews = new ArrayList<>();
+        reviews.add(SteamGameReview.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        reviews.add(SteamGameReview.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        List<SteamGameReviewResponse> expectedReviewResponses = new ArrayList<>();
+        expectedReviewResponses.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expectedReviewResponses.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        when(springDataSteamGameReviewRepository.findAllByGameSteamId(1)).thenReturn(reviews);
+
+        var result = steamGameReviewRepositoryImpl.findAllByGameSteamId(1);
+
+        assertEquals(Optional.of(expectedReviewResponses), result);
+    }
+
+    @Test
+    public void testFindAllByGameSteamId_NonexistentGame() {
+        when(steamGameGateway.getSteamGameBySteamId(anyInt())).thenReturn(Optional.empty());
+
+        var result = steamGameReviewRepositoryImpl.findAllByGameSteamId(1);
+
+        assertEquals(Optional.empty(), result);
+    }
+
+    @Test
+    public void testFindAllByGameName() {
+        when(steamGameGateway.getSteamGameByName(anyString()))
+                .thenReturn(Optional.of(SteamGame.builder().gameSteamId(1).gameName("game1").build()));
+        List<SteamGameReview> reviews = new ArrayList<>();
+        reviews.add(SteamGameReview.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        reviews.add(SteamGameReview.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        List<SteamGameReviewResponse> expectedReviewResponses = new ArrayList<>();
+        expectedReviewResponses.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expectedReviewResponses.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user2")
+                .reviewContent("review2")
+                .build());
+
+        when(springDataSteamGameReviewRepository.findAllByGameSteamId(1)).thenReturn(reviews);
+
+        var result = steamGameReviewRepositoryImpl.findAllByGameName("game1");
+
+        assertEquals(Optional.of(expectedReviewResponses), result);
+    }
+
+    @Test
+    public void testFindAllByGameName_NonexistentGame() {
+        when(steamGameGateway.getSteamGameByName(anyString())).thenReturn(Optional.empty());
+
+        var result = steamGameReviewRepositoryImpl.findAllByGameName("nonexistentGame");
+
+        assertEquals(Optional.empty(), result);
+    }
+
+    @Test
+    public void testFindAllByUserName() {
+        when(springDataUserRepository.findByUsername(anyString()))
+                .thenReturn(Optional.of(User.builder().username("user1").build()));
+        List<SteamGameReview> reviews = new ArrayList<>();
+        reviews.add(SteamGameReview.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        reviews.add(SteamGameReview.builder()
+                .gameSteamId(2)
+                .gameName("game2")
+                .userName("user1")
+                .reviewContent("review2")
+                .build());
+
+        List<SteamGameReviewResponse> expectedReviewResponses = new ArrayList<>();
+        expectedReviewResponses.add(SteamGameReviewResponse.builder()
+                .gameSteamId(1)
+                .gameName("game1")
+                .userName("user1")
+                .reviewContent("review1")
+                .build());
+        expectedReviewResponses.add(SteamGameReviewResponse.builder()
+                .gameSteamId(2)
+                .gameName("game2")
+                .userName("user1")
+                .reviewContent("review2")
+                .build());
+
+        when(springDataSteamGameReviewRepository.findAllByUserName("user1")).thenReturn(reviews);
+
+        var result = steamGameReviewRepositoryImpl.findAllByUserName("user1");
+
+        assertEquals(Optional.of(expectedReviewResponses), result);
+    }
+
+    @Test
+    public void testFindAllByUserName_NonexistentUser() {
+        when(springDataUserRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+
+        var result = steamGameReviewRepositoryImpl.findAllByUserName("nonexistentUser");
+
+        assertEquals(Optional.empty(), result);
+    }
+
+    @Test
+    public void testSave() {
+        when(steamGameGateway.getSteamGameBySteamId(anyInt()))
+                .thenReturn(Optional.of(SteamGame.builder().gameSteamId(1).build()));
+        when(springDataSteamGameReviewRepository.save(any()))
+                .thenReturn(SteamGameReview.builder().gameSteamId(1).build());
+
+        var result = steamGameReviewRepositoryImpl.save(SteamGameReview.builder().gameSteamId(1).build());
+
+        assertNotNull(result.get());
+        assertEquals(1, result.get().getGameSteamId());
+    }
+
+    @Test
+    public void testSave_InexistentGame() {
+        when(steamGameGateway.getSteamGameBySteamId(anyInt())).thenReturn(Optional.empty());
+
+        var result = steamGameReviewRepositoryImpl.save(SteamGameReview.builder().gameSteamId(1).build());
+
+        assertEquals(Optional.empty(), result);
+    }
+}


### PR DESCRIPTION
- Add tests for review feature: coverage 100% for everything under `reviews`
- Remove validation for valid steam game name, since there were never any invalid cases to begin with
- Remove `SteamGameValidationException` since it was only used in the case above
- Added `lombok.config` file so that Lombok generated code isn't included in Jacoco test coverage report

