### PR TITLE
(Hardening) Ensure docker-compose V1 is installed on build

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           java-version: 1.21
 
+      - name: Set up Docker Compose
+        run: sudo apt-get install docker-compose
+
       - name: Start Docker - Database Container & Compile Application
         run: |
           docker-compose up -d


### PR DESCRIPTION
PR build has become flakey due to migration of Github Actions Ubuntu Runner Image from Docker Compose V1 to V2: [see here](https://github.com/actions/runner-images/issues/9557). The migration started on April 1st and was planned to take a few days, which lead to flaky builds - unpredicability if you'd get the image with Docker Compose V1 or without, while the build was using Docker Compose V1.

This migration was reverted recently however, but this build change aims to ensure we won't be affected by those changes
Change:

- Added step to install Docker Compose V1 before running the command

I've also attempted to migrate to V2 separately, but it doesn't seem compatible with our current build setup, and would require more complex changes