### PR TITLE
(feature)alerting

### DIFF
--- a/h
+++ b/h
@@ -1,0 +1,1 @@
+grsdsbd

--- a/h
+++ b/h
@@ -1,1 +1,0 @@
-grsdsbd

--- a/infrastructure/prometheus/app-alerts.yml
+++ b/infrastructure/prometheus/app-alerts.yml
@@ -19,15 +19,17 @@ groups:
           summary: Increased info retrieval rate {{ $labels.value}} {{ $value }}
           description: "A container has disappeared\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
       
-      - alert: WARNING-HighThroughputGetAllGamesNoCount
-        expr: rate(getAllGamesCount_total{endpoint="getAllGamesWithoutCount"}[10s]) > 5
-        for: 10s
+        # Quality metric - error rate
+      - alert: WARNING-HighErrorRate
+        expr: rate(getAllGamesErrors_total{endpoint="getAllGamesNegativeCount"}[10s]) > 0
+        for: 1s
         labels:
           severity: warning
         annotations:
-            summary: Increased get all games no count rate {{ $labels.value}} {{ $value }}
-            description: "The getAllGamesWithoutCount endpoint is experiencing a high retrieval rate without counting\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+            summary: Increased get all games error rate {{ $labels.value}} {{ $value }}
+            description: "The getAllGamesWithoutCount endpoint is experiencing a high error rate\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
+      # Performance metric
       - alert: WARNING-LowPerformanceGetAllGames
         expr: avg_over_time(getAllGames_time_seconds_max[10s]) > 0.2
         for: 10s
@@ -37,8 +39,9 @@ groups:
           summary: Low performance in getAllGames endpoint {{ $labels.value}} {{ $value }}
           description: "The getAllGames endpoint is experiencing low performance\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
+      # Availability metric - external Steam API
       - alert: CRITICAL-SteamApiError
-        expr: rate(getAllGames.errors{endpoint="getAllGamesApiError"}[10s]) > 0
+        expr: rate(getAllGamesErrors_total{endpoint="getAllGamesApiError"}[10s]) > 0.1
         for: 10s
         labels:
           severity: critical

--- a/infrastructure/prometheus/app-alerts.yml
+++ b/infrastructure/prometheus/app-alerts.yml
@@ -21,8 +21,8 @@ groups:
       
         # Quality metric - error rate
       - alert: WARNING-HighErrorRate
-        expr: rate(getAllGamesErrors_total{endpoint="getAllGamesNegativeCount"}[10s]) > 0
-        for: 1s
+        expr: rate(getAllGamesErrors_total{endpoint="getAllGamesNegativeCount"}[10s]) > 0.01
+        for: 10s
         labels:
           severity: warning
         annotations:

--- a/infrastructure/prometheus/app-alerts.yml
+++ b/infrastructure/prometheus/app-alerts.yml
@@ -18,3 +18,30 @@ groups:
         annotations:
           summary: Increased info retrieval rate {{ $labels.value}} {{ $value }}
           description: "A container has disappeared\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+      
+      - alert: WARNING-HighThroughputGetAllGamesNoCount
+        expr: rate(getAllGamesCount_total{endpoint="getAllGamesWithoutCount"}[10s]) > 5
+        for: 10s
+        labels:
+          severity: warning
+        annotations:
+            summary: Increased get all games no count rate {{ $labels.value}} {{ $value }}
+            description: "The getAllGamesWithoutCount endpoint is experiencing a high retrieval rate without counting\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      - alert: WARNING-LowPerformanceGetAllGames
+        expr: avg_over_time(getAllGames_time_seconds_max[10s]) > 0.2
+        for: 10s
+        labels:
+          severity: warning
+        annotations:
+          summary: Low performance in getAllGames endpoint {{ $labels.value}} {{ $value }}
+          description: "The getAllGames endpoint is experiencing low performance\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+
+      - alert: CRITICAL-SteamApiError
+        expr: rate(getAllGames.errors{endpoint="getAllGamesApiError"}[10s]) > 0
+        for: 10s
+        labels:
+          severity: critical
+        annotations:
+          summary: Steam API error {{ $labels.value}} {{ $value }}
+          description: "The Steam API is experiencing errors\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"

--- a/src/main/java/ro/unibuc/triplea/domain/games/steam/service/SteamGameService.java
+++ b/src/main/java/ro/unibuc/triplea/domain/games/steam/service/SteamGameService.java
@@ -26,7 +26,7 @@ public class SteamGameService {
         Timer.Sample sample = Timer.start(meterRegistry);
         
         if(count.isPresent() && count.get() < 0) {
-            meterRegistry.counter("getAllGames.errors", "endpoint", "getAllGamesNegativeCount").increment();
+            meterRegistry.counter("getAllGamesErrors", "endpoint", "getAllGamesNegativeCount").increment();
             throw new IllegalArgumentException("Count must be a positive number");
         }
 
@@ -42,11 +42,11 @@ public class SteamGameService {
         List<SteamGameResponse> games = steamGameRepository.findGames(count);
 
         if(games.isEmpty()) {
-            meterRegistry.counter("getAllGames.errors", "endpoint", "getAllGamesApiError").increment();
+            meterRegistry.counter("getAllGamesErrors", "endpoint", "getAllGamesApiError").increment();
             throw new SteamGameNotFoundException("No games found");
         }
 
-        sample.stop(meterRegistry.timer("getAllGames.time"));
+        sample.stop(meterRegistry.timer("getAllGamesTime"));
 
         return games;
 


### PR DESCRIPTION
Add Alert Manager alerting, with metrics for categories:
- availability: external Steam API error rate
- performance: performance of get all games endpoint
- quality: rate of errors returned by get all games endpoint

Email configs need to be updated in alertmanager.yaml